### PR TITLE
feat: use etherscan to fetch abi for base

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -25,8 +25,5 @@ class DummyChain(EtherscanMixin, Chain):
 
 @pytest.fixture
 async def chain():
-    chain = DummyChain()
-    try:
+    async with DummyChain() as chain:
         yield chain
-    finally:
-        await chain.aclose()

--- a/integration_tests/networks/ethereum/test_mainnet_async.py
+++ b/integration_tests/networks/ethereum/test_mainnet_async.py
@@ -10,10 +10,8 @@ async def eth_chain():
     chain = EthereumMainnetChain(
         abis_path="integration_tests/abis/ethereum/",
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 async def test_call_contract_function(eth_chain):

--- a/integration_tests/networks/gnosis/test_mainnet_async.py
+++ b/integration_tests/networks/gnosis/test_mainnet_async.py
@@ -8,10 +8,8 @@ async def gnosis_chain():
     chain = GnosisMainnetChain(
         abis_path="integration_tests/abis/gnosis/",
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 async def test_call_contract_function(gnosis_chain):

--- a/integration_tests/networks/hyperliquid/test_mainnet_async.py
+++ b/integration_tests/networks/hyperliquid/test_mainnet_async.py
@@ -8,10 +8,8 @@ async def hype_chain():
     chain = HyperliquidMainnetChain(
         abis_path="integration_tests/abis/hyperliquid/",
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 async def test_latest_block(hype_chain):

--- a/integration_tests/networks/linea/test_mainnet_async.py
+++ b/integration_tests/networks/linea/test_mainnet_async.py
@@ -8,10 +8,8 @@ async def linea_chain():
     chain = LineaMainnetChain(
         abis_path="integration_tests/abis/linea/",
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 async def test_multicall(linea_chain):

--- a/integration_tests/networks/plasma/test_mainnet_async.py
+++ b/integration_tests/networks/plasma/test_mainnet_async.py
@@ -8,10 +8,8 @@ async def plasma_chain():
     chain = PlasmaMainnetChain(
         abis_path="integration_tests/abis/plasma/",
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 async def test_latest_block(plasma_chain):

--- a/integration_tests/networks/rari/test_mainnet_async.py
+++ b/integration_tests/networks/rari/test_mainnet_async.py
@@ -8,10 +8,8 @@ async def rari_chain():
     chain = RariMainnetChain(
         abis_path="integration_tests/abis/rari/",
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 async def test_multicall(rari_chain):

--- a/integration_tests/networks/tempo/test_mainnet_async.py
+++ b/integration_tests/networks/tempo/test_mainnet_async.py
@@ -2,35 +2,29 @@ from chain_harvester_async.networks.tempo import TempoMainnetChain
 
 
 async def test_multicall():
-    chain = TempoMainnetChain()
-
-    calls = []
-    calls.append(
-        (
-            "0x891b473fe15ccce37827dde41f70d6ed4d607dfe",
-            ["shareDecimals()(int)"],
-            ["shareDecimals", None],
+    async with TempoMainnetChain() as chain:
+        calls = []
+        calls.append(
+            (
+                "0x891b473fe15ccce37827dde41f70d6ed4d607dfe",
+                ["shareDecimals()(int)"],
+                ["shareDecimals", None],
+            )
         )
-    )
-    calls.append(
-        (
-            "0x891b473fe15ccce37827dde41f70d6ed4d607dfe",
-            ["shareUnit()(int)"],
-            ["shareUnit", None],
+        calls.append(
+            (
+                "0x891b473fe15ccce37827dde41f70d6ed4d607dfe",
+                ["shareUnit()(int)"],
+                ["shareUnit", None],
+            )
         )
-    )
-    result = await chain.multicall(calls)
-    assert len(result) == 2
-
-    await chain.aclose()
+        result = await chain.multicall(calls)
+        assert len(result) == 2
 
 
 async def test_call_contract_function():
-    chain = TempoMainnetChain()
-
-    share_price = await chain.call_contract_function(
-        "0x891b473fe15ccce37827dde41f70d6ed4d607dfe", "getSharePrice"
-    )
-    assert share_price > 1
-
-    await chain.aclose()
+    async with TempoMainnetChain() as chain:
+        share_price = await chain.call_contract_function(
+            "0x891b473fe15ccce37827dde41f70d6ed4d607dfe", "getSharePrice"
+        )
+        assert share_price > 1

--- a/integration_tests/networks/tenderly/test_tenderly_async.py
+++ b/integration_tests/networks/tenderly/test_tenderly_async.py
@@ -12,10 +12,8 @@ async def t_chain():
         project=os.environ.get("TENDERLY_PROJECT"),
         testnet_id=os.environ.get("TENDERLY_TESTNET_ID"),
     )
-    try:
-        yield chain
-    finally:
-        await chain.aclose()
+    async with chain as c:
+        yield c
 
 
 @pytest.mark.skip(reason="Only for manual testing")

--- a/src/chain_harvester_async/networks/base.py
+++ b/src/chain_harvester_async/networks/base.py
@@ -1,9 +1,52 @@
+import json
+import logging
+import urllib.parse
+
+from environs import env
+
+from chain_harvester.exceptions import ChainException
 from chain_harvester_async.chain import Chain
 from chain_harvester_async.mixins import BlockscoutMixin
+from chain_harvester_async.utils.http import retry_get_json
+
+log = logging.getLogger(__name__)
 
 
 class BaseMainnetChain(BlockscoutMixin, Chain):
     latest_block_offset = 30
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, etherscan_api_key=None, **kwargs):
+        self.etherscan_api_key = etherscan_api_key or env("ETHERSCAN_API_KEY", None)
+        self.etherscan_url = "https://api.etherscan.io/v2"
         super().__init__(*args, chain="base", network="mainnet", **kwargs)
+
+    async def get_abi_from_source(self, contract_address):
+        """
+        We still want to use etherscan to fetch abi's, because blockscout is unreliable for
+        fetching ABIs. Basically the only reason we use blockscout is in order to be able to
+        call `get_closest_block_before_timestamp` which basescan doesnt support.
+        """
+        query_params = {
+            "chainid": self.chain_id,
+            "module": "contract",
+            "action": "getabi",
+            "address": contract_address,
+            "apikey": self.etherscan_api_key,
+        }
+        url = f"{self.etherscan_url}/api?{urllib.parse.urlencode(query_params)}"
+
+        try:
+            data = await retry_get_json(url, timeout=5)
+        except TimeoutError:
+            log.exception(
+                "Timeout when getting abi from %s",
+                self.etherscan_url,
+                extra={"contract_address": contract_address},
+            )
+            raise
+
+        if data["status"] != "1":
+            raise ChainException(f"Request to {self.etherscan_url} failed: {data['result']}")
+
+        abi = json.loads(data["result"])
+        return abi


### PR DESCRIPTION
For base network use etherscan instead of blockscout to fetch abi.