### PR TITLE
fix: raise instead of silently clamping to_block to hypersync archive height

### DIFF
--- a/src/chain_harvester/exceptions.py
+++ b/src/chain_harvester/exceptions.py
@@ -9,3 +9,15 @@ class ChainHarvesterError(Exception):
 
 class ConfigError(ChainHarvesterError):
     pass
+
+
+class ArchiveHeightBehindError(ChainHarvesterError):
+    """The hypersync replica serving a query has indexed fewer blocks than the
+    requested to_block, so the requested range cannot be fully covered."""
+
+    def __init__(self, to_block, archive_height):
+        self.to_block = to_block
+        self.archive_height = archive_height
+        super().__init__(
+            f"hypersync archive height {archive_height} is behind requested to_block {to_block}"
+        )

--- a/src/chain_harvester_async/adapters/envio.py
+++ b/src/chain_harvester_async/adapters/envio.py
@@ -12,6 +12,7 @@ from hypersync import (
 )
 
 from chain_harvester.decoders import MissingABIEventDecoderError
+from chain_harvester.exceptions import ArchiveHeightBehindError
 from chain_harvester_async.blocks import BlockStore
 
 log = logging.getLogger(__name__)
@@ -55,7 +56,6 @@ async def fetch_enriched_events(
     anonymous=False,
     mixed=False,
 ):
-    call_count = 0
     while from_block < to_block:
         query = Query(
             from_block=from_block,
@@ -91,14 +91,15 @@ async def fetch_enriched_events(
         )
         log.debug("Fetching events for contracts topics from block %s to %s", from_block, to_block)
         res = await chain.hypersync_client.get(query)
-        call_count += 1
 
         from_block = res.next_block
 
-        # Set to_block to res.archive_height on first request if it's bigger than
-        # res.archive_height to prevent infinte loop (especially on fast chains)
-        if call_count == 1 and to_block > res.archive_height:
-            to_block = res.archive_height
+        # The replica answering this query can lag behind the one that answered
+        # get_height(), so silently clamping to res.archive_height would skip
+        # (archive_height, to_block] while callers believe the whole range was
+        # covered (and checkpoint past it). Fail loudly so callers retry later.
+        if to_block > res.archive_height:
+            raise ArchiveHeightBehindError(to_block=to_block, archive_height=res.archive_height)
 
         blocks = {}
         for block in res.data.blocks:

--- a/tests/adapters/test_envio.py
+++ b/tests/adapters/test_envio.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chain_harvester.exceptions import ArchiveHeightBehindError
+from chain_harvester_async.adapters.envio import fetch_enriched_events
+
+
+def make_response(next_block, archive_height, blocks=None, logs=None):
+    return SimpleNamespace(
+        next_block=next_block,
+        archive_height=archive_height,
+        data=SimpleNamespace(blocks=blocks or [], logs=logs or []),
+    )
+
+
+def make_chain(responses):
+    chain = MagicMock()
+    chain.block_store = None
+    chain.hypersync_client.get = AsyncMock(side_effect=responses)
+    return chain
+
+
+async def test_raises_when_archive_height_behind_requested_to_block():
+    chain = make_chain([make_response(next_block=971, archive_height=970)])
+
+    events = fetch_enriched_events(chain, ["0xabc"], 950, 988)
+
+    with pytest.raises(ArchiveHeightBehindError) as exc_info:
+        await anext(events)
+    assert exc_info.value.to_block == 988
+    assert exc_info.value.archive_height == 970
+
+
+async def test_raises_when_archive_height_falls_behind_mid_pagination():
+    chain = make_chain(
+        [
+            make_response(next_block=960, archive_height=1000),
+            make_response(next_block=970, archive_height=980),
+        ]
+    )
+
+    events = fetch_enriched_events(chain, ["0xabc"], 950, 988)
+
+    with pytest.raises(ArchiveHeightBehindError) as exc_info:
+        await anext(events)
+    assert exc_info.value.to_block == 988
+    assert exc_info.value.archive_height == 980
+
+
+async def test_yields_events_when_archive_covers_range():
+    block = SimpleNamespace(number=960, hash="0x" + "11" * 32, timestamp=hex(1700000000))
+    log_entry = SimpleNamespace(
+        log_index=0,
+        transaction_index=0,
+        transaction_hash="0x" + "22" * 32,
+        block_number=960,
+        block_hash="0x" + "11" * 32,
+        address="0xabc",
+        data="0x",
+        topics=["0x" + "33" * 32],
+    )
+    chain = make_chain(
+        [make_response(next_block=989, archive_height=1000, blocks=[block], logs=[log_entry])]
+    )
+    chain.get_contract = AsyncMock(return_value=MagicMock())
+    chain._decode_raw_log = MagicMock(return_value={"event": "Staked"})
+
+    events = [event async for event in fetch_enriched_events(chain, ["0xabc"], 950, 988)]
+
+    assert len(events) == 1
+    assert events[0]["event"] == "Staked"
+    assert events[0]["blockTimestamp"] == 1700000000


### PR DESCRIPTION
When the hypersync replica serving a data query lags behind the one that answered get_height(), fetch_enriched_events silently clamped to_block down to res.archive_height and finished as if the whole range was covered. Callers that checkpoint to_block after a "successful" run then permanently skip (archive_height, to_block] — this is exactly how sky's ingest pipelines can lose events during hypersync degradations (blockanalitica/sky#69).

Now the adapter raises ArchiveHeightBehindError (carrying to_block and archive_height) so callers fail loudly and retry once the archive catches up — events already saved from earlier pages are re-fetched idempotently. The check also runs on every page instead of just the first, so a replica switch mid-pagination can't silently truncate the range either.