### PR TITLE
fix: async get_logs step handling — infinite loops + hypersync full range

### DIFF
--- a/src/chain_harvester_async/chain.py
+++ b/src/chain_harvester_async/chain.py
@@ -1027,7 +1027,9 @@ class Chain:
             filters["topics"] = topics
 
         retries = defaultdict(int)
-        step = to_block - from_block
+        # Seed from the chain's configured step so callers can bound the initial
+        # request (e.g. ROBINHOOD_RPC_STEP) instead of always asking for the full range.
+        step = min(self.step, to_block - from_block) if self.step else to_block - from_block
 
         while True:
             end_block = min(from_block + step - 1, to_block)
@@ -1063,10 +1065,14 @@ class Chain:
                 if code == -32602 and "log response size exceeded" in msg.lower():
                     try:
                         hex_values = re.findall(r"0x[0-9a-fA-F]+", msg)
-                        step = int(hex_values[1], 16) - int(hex_values[0], 16)
-                    except Exception as e:
+                        suggested = int(hex_values[1], 16) - int(hex_values[0], 16)
+                    except Exception:
                         log.warning("Couldn't extract step size from msg: %s", msg)
-                        step = max(step // 2, 10)
+                        suggested = step
+                    # The suggested range is block-count based; on log-dense chains it can
+                    # equal the current step (too many logs, not too many blocks), which would
+                    # loop forever. Always make progress by halving if it doesn't shrink.
+                    step = suggested if suggested < step else max(step // 2, 10)
 
                 log.info("Retrying `get_logs` with step: %s", step)
                 continue

--- a/src/chain_harvester_async/chain.py
+++ b/src/chain_harvester_async/chain.py
@@ -1027,9 +1027,15 @@ class Chain:
             filters["topics"] = topics
 
         retries = defaultdict(int)
-        # Seed from the chain's configured step so callers can bound the initial
-        # request (e.g. ROBINHOOD_RPC_STEP) instead of always asking for the full range.
-        step = min(self.step, to_block - from_block) if self.step else to_block - from_block
+        # Hypersync paginates arbitrarily large ranges natively; chunking it into
+        # self.step-sized windows makes it far slower than the RPC it replaces.
+        # So only bound the initial request for plain-RPC chains (e.g. Alchemy wants
+        # a max step, see ROBINHOOD_RPC_STEP); hypersync always asks for the full range.
+        full_range = to_block - from_block
+        if self.use_hypersync or not self.step:
+            step = full_range
+        else:
+            step = min(self.step, full_range)
 
         while True:
             end_block = min(from_block + step - 1, to_block)

--- a/src/chain_harvester_async/chain.py
+++ b/src/chain_harvester_async/chain.py
@@ -1031,7 +1031,11 @@ class Chain:
         # self.step-sized windows makes it far slower than the RPC it replaces.
         # So only bound the initial request for plain-RPC chains (e.g. Alchemy wants
         # a max step, see ROBINHOOD_RPC_STEP); hypersync always asks for the full range.
-        full_range = to_block - from_block
+        # Inclusive block count: from_block == to_block is a 1-block range. The old
+        # `to_block - from_block` yielded step 0 there, making end_block an inverted
+        # range and `from_block += step` a no-op — an infinite loop on RPCs that
+        # answer an inverted range with an empty result instead of an error.
+        full_range = to_block - from_block + 1
         if self.use_hypersync or not self.step:
             step = full_range
         else:
@@ -1063,7 +1067,9 @@ class Chain:
                 elif code == -32600:
                     try:
                         hex_values = re.findall(r"0x[0-9a-fA-F]+", msg)
-                        step = int(hex_values[1], 16) - int(hex_values[0], 16)
+                        # A suggested [a, b] range is b - a + 1 blocks; also floors a
+                        # single-block suggestion at 1 instead of a stalling step 0.
+                        step = max(int(hex_values[1], 16) - int(hex_values[0], 16), 1)
                     except Exception:
                         log.warning("Couldn't extract step size from msg: %s", msg)
                         step = max(step // 2, 10)
@@ -1071,7 +1077,7 @@ class Chain:
                 if code == -32602 and "log response size exceeded" in msg.lower():
                     try:
                         hex_values = re.findall(r"0x[0-9a-fA-F]+", msg)
-                        suggested = int(hex_values[1], 16) - int(hex_values[0], 16)
+                        suggested = max(int(hex_values[1], 16) - int(hex_values[0], 16), 1)
                     except Exception:
                         log.warning("Couldn't extract step size from msg: %s", msg)
                         suggested = step
@@ -1091,7 +1097,10 @@ class Chain:
             if end_block >= to_block:
                 break
 
-            from_block += step
+            # Advance past the window actually fetched — immune to whatever the
+            # retry branches did to `step` (unlike `from_block += step`, which
+            # stalls forever if step ever reaches 0).
+            from_block = end_block + 1
 
     async def _fetch_events_from_rpc(
         self,

--- a/tests/test_fetch_logs_async.py
+++ b/tests/test_fetch_logs_async.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock
+
+from chain_harvester_async.chain import Chain
+
+RPC_NODES = {
+    "ethereum": {
+        "mainnet": "http://localhost:8545",
+    },
+}
+
+
+def make_chain():
+    return Chain(
+        chain="ethereum",
+        network="mainnet",
+        rpc="http://localhost:8545",
+        step=10_000,
+    )
+
+
+async def collect_logs(chain, from_block, to_block):
+    return [log async for log in chain._fetch_logs_from_rpc([], from_block, to_block)]
+
+
+async def test_fetch_logs_single_block_range_terminates(monkeypatch):
+    """from_block == to_block is a 1-block range: one request, no infinite loop."""
+    chain = make_chain()
+    get_logs = AsyncMock(return_value=[])
+    eth = type("Eth", (), {"get_logs": get_logs})()
+    monkeypatch.setattr(chain, "_w3", type("W3", (), {"eth": eth})())
+
+    logs = await collect_logs(chain, 100, 100)
+
+    assert logs == []
+    assert get_logs.await_count == 1
+    filters = get_logs.await_args.args[0]
+    assert filters["fromBlock"] == hex(100)
+    assert filters["toBlock"] == hex(100)
+
+
+async def test_fetch_logs_chunks_cover_full_inclusive_range(monkeypatch):
+    """Windows advance past the fetched end_block and cover [from, to] exactly once."""
+    chain = make_chain()
+    chain.step = 10
+    seen = []
+
+    async def fake_get_logs(filters):
+        seen.append((int(filters["fromBlock"], 16), int(filters["toBlock"], 16)))
+        return []
+
+    eth = type("Eth", (), {"get_logs": staticmethod(fake_get_logs)})()
+    monkeypatch.setattr(chain, "_w3", type("W3", (), {"eth": eth})())
+
+    await collect_logs(chain, 0, 24)
+
+    assert seen == [(0, 9), (10, 19), (20, 24)]


### PR DESCRIPTION
Three related fixes to `chain_harvester_async`'s `_fetch_logs_from_rpc` loop:

1. **`from_block == to_block` infinite loop**: `step = to_block - from_block` is 0 for a single-block range → `end_block = from_block - 1` (inverted) → `from_block += 0` loops the identical request forever when the RPC answers an inverted range with an empty result instead of an error. Hits any caught-up processor on a quiet chain — watermark == head on every run (e.g. sky's new tempo/robinhood/xlayer token pipelines, sky#274). Fixed with inclusive range count (`to - from + 1`), advancing via `from_block = end_block + 1` (immune to any `step` mutation), and flooring the error-message-suggested steps at 1.

2. **Suggested-step non-shrink loop**: the -32602 "log response size exceeded" suggested range is block-count based and can equal the current step on log-dense chains; now halves whenever the suggestion doesn't shrink.

3. **Hypersync full range**: hypersync paginates natively; chunking into `self.step` windows made it slower than plain RPC. Hypersync now requests the full range; plain-RPC chains keep the step bound. (Still needs a local hypersync run before merge per earlier note.)

Regression tests added: single-block range terminates in one request; chunked windows cover `[from, to]` inclusively exactly once. Full suite passes (24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)