### PR TITLE
fix: tolerate event ABI entries without the anonymous field

### DIFF
--- a/src/chain_harvester/decoders.py
+++ b/src/chain_harvester/decoders.py
@@ -71,7 +71,11 @@ class EventRawLogDecoder:
 class EventLogDecoder:
     def __init__(self, contract):
         self._contract = contract
-        event_abis = [abi for abi in self._contract.abi if abi["type"] == "event"]
+        # some explorers (e.g. OKLink) strip the "anonymous" field from event
+        # entries, but web3's event decoder requires it
+        event_abis = [
+            {"anonymous": False, **abi} for abi in self._contract.abi if abi["type"] == "event"
+        ]
         self._signed_abis = {event_abi_to_log_topic(abi): abi for abi in event_abis}
 
     def decode_log(self, log_entry):


### PR DESCRIPTION
OKLink serves verified-contract ABIs with the `anonymous` field stripped from event entries (verified live against XLAYER: both the spUSDT proxy and its SparkVaultV2 implementation return 15/15 events without it). web3's `get_event_data` requires the field, so the first datahub xlayer tokens run died with `KeyError: 'anonymous'` while decoding the Transfer backfill.

`EventLogDecoder` now defaults `anonymous` to `False` when building its event ABIs. The fix is decoder-side rather than in the OKLink mixin because fetched ABIs get cached (S3 + local `abis/`) — a fetch-time normalization would never reach ABIs already cached unnormalized (the broken one is already in the S3 cache from the failed run). Covers both sync and async libs (async imports this decoder).

Verified E2E: full datahub xlayer pipeline run against mainnet with this fix decodes the spUSDT events cleanly (blockanalitica/office#487).