### PR TITLE
fix: raise HTTP error statuses with non-JSON bodies instead of JSONDecodeError

### DIFF
--- a/src/chain_harvester_async/w3_provider.py
+++ b/src/chain_harvester_async/w3_provider.py
@@ -1,15 +1,42 @@
+import json
+
+from aiohttp import ClientResponseError
 from web3 import AsyncHTTPProvider
 from web3._utils.http_session_manager import HTTPSessionManager
 
 
+def _is_json(body):
+    try:
+        json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return False
+    return True
+
+
 class CustomHTTPSessionManager(HTTPSessionManager):
     async def async_make_post_request(self, endpoint_uri, data, **kwargs):
-        # We override this function to remove `response.raise_for_status()` so we get
-        # better errors
+        # Web3's stock session manager calls `response.raise_for_status()`, which
+        # discards the body — but some RPCs return JSON-RPC error payloads with a
+        # non-200 status, and those must reach web3's decoder so the caller sees the
+        # RPC's actual error. An error status WITHOUT a JSON body (a bare 429/5xx
+        # from a rate limiter or proxy) is different: passed through, it surfaces as
+        # JSONDecodeError('') in the decoder and silently bypasses the provider's
+        # ExceptionRetryConfiguration (which retries ClientError subclasses), so
+        # raise it as the ClientResponseError it really is.
         response = await self.async_get_response_from_post_request(
             endpoint_uri, data=data, **kwargs
         )
-        return await response.read()
+        body = await response.read()
+        if response.status >= 400 and not _is_json(body):
+            snippet = body[:200].decode(errors="replace")
+            raise ClientResponseError(
+                response.request_info,
+                response.history,
+                status=response.status,
+                message=f"{response.reason}; body={snippet!r}",
+                headers=response.headers,
+            )
+        return body
 
 
 class CustomAsyncHTTPProvider(AsyncHTTPProvider):

--- a/tests/test_w3_provider_async.py
+++ b/tests/test_w3_provider_async.py
@@ -1,0 +1,55 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import ClientResponseError
+
+from chain_harvester_async.w3_provider import CustomHTTPSessionManager
+
+
+def _response(status, body, reason="Error"):
+    return SimpleNamespace(
+        status=status,
+        reason=reason,
+        headers={},
+        request_info=None,
+        history=(),
+        read=AsyncMock(return_value=body),
+    )
+
+
+async def _post(response):
+    manager = CustomHTTPSessionManager()
+    manager.async_get_response_from_post_request = AsyncMock(return_value=response)
+    return await manager.async_make_post_request("http://localhost:8545", b"{}")
+
+
+async def test_ok_json_body_passes_through():
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "result": "0x1"}).encode()
+    assert await _post(_response(200, body)) == body
+
+
+async def test_error_status_with_json_body_passes_through():
+    # Some RPCs return the JSON-RPC error payload with a non-200 status; web3 must
+    # receive it so the caller sees the RPC's own error message.
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "error": {"code": -32005, "message": "rate limited"}}
+    ).encode()
+    assert await _post(_response(429, body)) == body
+
+
+async def test_error_status_with_empty_body_raises():
+    # A bare 429 with an empty body must raise a retryable ClientError, not leak
+    # into web3's JSON decoder as JSONDecodeError('').
+    with pytest.raises(ClientResponseError) as exc_info:
+        await _post(_response(429, b"", reason="Too Many Requests"))
+    assert exc_info.value.status == 429
+    assert "Too Many Requests" in exc_info.value.message
+
+
+async def test_error_status_with_html_body_raises():
+    with pytest.raises(ClientResponseError) as exc_info:
+        await _post(_response(502, b"<html>Bad Gateway</html>", reason="Bad Gateway"))
+    assert exc_info.value.status == 502
+    assert "<html>Bad Gateway</html>" in exc_info.value.message


### PR DESCRIPTION
An error status with an empty or non-JSON body currently flows into web3's response decoder and surfaces as `JSONDecodeError: Could not decode ''` — this is exactly how rpc2.monad.xyz's hard 429s looked in sky's Sentry for 18 days (blockanalitica/sky#269 has the incident context). Worse, because `CustomHTTPSessionManager` strips `raise_for_status()`, those responses also bypass the provider's own `ExceptionRetryConfiguration`, which retries `ClientError` subclasses — so 429/5xx never got their retries with backoff.

Now an error status with a non-JSON body raises `ClientResponseError` carrying the status and a body snippet: transient 429s/5xxs get retried, and sustained ones fail with an honest error. Error statuses that carry a JSON-RPC error payload still pass through to web3 untouched — preserving the reason `raise_for_status()` was removed in the first place.