### PR TITLE
feat: alchemy historical price series + the 5 reserve networks

### DIFF
--- a/src/chain_harvester_async/adapters/alchemy.py
+++ b/src/chain_harvester_async/adapters/alchemy.py
@@ -1,10 +1,28 @@
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 from chain_harvester_async.utils.http import retry_post_json
 
 ALCHEMY_API_KEY = os.environ.get("ALCHEMY_RPC_KEY", "")
+
+PRICE_NETWORKS = {
+    "ethereum": "eth-mainnet",
+    "arbitrum": "arb-mainnet",
+    "base": "base-mainnet",
+    "polygon": "polygon-mainnet",
+    "optimism": "opt-mainnet",
+    "unichain": "unichain-mainnet",
+    "linea": "linea-mainnet",
+    "scroll": "scroll-mainnet",
+    "monad": "monad-mainnet",
+}
+
+# The historical endpoint rejects a 1d interval covering more than 365 points, so longer
+# windows are requested one chunk at a time.
+PRICE_SERIES_MAX_DAYS = 365
+
+PRICE_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class AlchemyClientError(Exception):
@@ -59,36 +77,28 @@ async def get_blocks(url, from_block, to_block=None, limit=10000, timeout=30, re
         skip += first
 
 
-async def get_token_price(address, network, dt):
-    network_mapping = {
-        "ethereum": "eth-mainnet",
-        "arbitrum": "arb-mainnet",
-        "base": "base-mainnet",
-        "monad": "monad-mainnet",
-    }
-
-    if network == "monad":
-        # alchemy doesnt support monad ...
-        return
-
-    alchemy_network = network_mapping.get(network)
+def _price_network(network):
+    alchemy_network = PRICE_NETWORKS.get(network)
     if not alchemy_network:
         raise ValueError(
             f"Network '{network}' does not exists in our network mapping. "
-            f"Supported: {', '.join(network_mapping.keys())}"
+            f"Supported: {', '.join(PRICE_NETWORKS.keys())}"
         )
+    return alchemy_network
 
+
+def _price_timestamp(dt):
+    return datetime.combine(dt, datetime.min.time(), tzinfo=UTC).strftime(PRICE_TIMESTAMP_FORMAT)
+
+
+async def _fetch_prices(address, alchemy_network, start, end):
     url = f"https://api.g.alchemy.com/prices/v1/{ALCHEMY_API_KEY}/tokens/historical"
-
-    dt = datetime.combine(dt, datetime.min.time(), tzinfo=UTC)
-    start_time = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-    end_time = start_time
 
     payload = {
         "address": address,
         "network": alchemy_network,
-        "startTime": start_time,
-        "endTime": end_time,
+        "startTime": _price_timestamp(start),
+        "endTime": _price_timestamp(end),
         "interval": "1d",
     }
     resp = await retry_post_json(
@@ -101,18 +111,45 @@ async def get_token_price(address, network, dt):
     )
 
     if not resp:
-        return
+        return []
 
     resp_json = await resp.json()
 
     if err := resp_json.get("error", {}).get("message"):
         if "Token not found" in err:
-            return None
+            return []
         raise AlchemyClientError(err)
 
-    data = resp_json.get("data", [])
-    if len(data) > 0:
-        price = Decimal(data[0]["value"])
-        return price
+    return resp_json.get("data", [])
+
+
+async def get_token_price(address, network, dt):
+    if network == "monad":
+        # alchemy doesnt support monad ...
+        return
+
+    data = await _fetch_prices(address, _price_network(network), dt, dt)
+    if data:
+        return Decimal(data[0]["value"])
 
     return
+
+
+async def get_token_price_series(address, network, start_date, end_date):
+    if network == "monad":
+        # alchemy doesnt support monad ...
+        return {}
+
+    alchemy_network = _price_network(network)
+    prices = {}
+    window_start = start_date
+    while window_start <= end_date:
+        window_end = min(
+            window_start + timedelta(days=PRICE_SERIES_MAX_DAYS - 1),
+            end_date,
+        )
+        for entry in await _fetch_prices(address, alchemy_network, window_start, window_end):
+            day = datetime.fromisoformat(entry["timestamp"]).date()
+            prices[day] = Decimal(entry["value"])
+        window_start = window_end + timedelta(days=1)
+    return prices

--- a/src/chain_harvester_async/prices.py
+++ b/src/chain_harvester_async/prices.py
@@ -7,3 +7,7 @@ async def get_tokens_price(addresses, timestamp, network="ethereum"):
 
 async def get_alchemy_token_price(address, network, dt):
     return await alchemy.get_token_price(address, network, dt)
+
+
+async def get_alchemy_token_price_series(address, network, start_date, end_date):
+    return await alchemy.get_token_price_series(address, network, start_date, end_date)

--- a/tests/adapters/test_alchemy.py
+++ b/tests/adapters/test_alchemy.py
@@ -1,0 +1,113 @@
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from chain_harvester_async.adapters.alchemy import (
+    AlchemyClientError,
+    get_token_price,
+    get_token_price_series,
+)
+
+USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+
+def make_response(body):
+    response = AsyncMock()
+    response.json.return_value = body
+    return response
+
+
+def point(day, value):
+    return {"timestamp": f"2024-01-{day:02d}T00:00:00Z", "value": value}
+
+
+async def test_get_token_price_returns_the_single_day_value():
+    with patch(
+        "chain_harvester_async.adapters.alchemy.retry_post_json",
+        AsyncMock(return_value=make_response({"data": [point(1, "0.9992")]})),
+    ):
+        assert await get_token_price(USDC, "ethereum", date(2024, 1, 1)) == Decimal("0.9992")
+
+
+async def test_get_token_price_returns_none_for_an_unpriced_token():
+    body = {"error": {"message": "Token not found: 0xeee"}}
+    with patch(
+        "chain_harvester_async.adapters.alchemy.retry_post_json",
+        AsyncMock(return_value=make_response(body)),
+    ):
+        assert await get_token_price(USDC, "ethereum", date(2024, 1, 1)) is None
+
+
+async def test_get_token_price_raises_on_other_api_errors():
+    body = {"error": {"message": "1d interval is limited to 365 days"}}
+    with (
+        patch(
+            "chain_harvester_async.adapters.alchemy.retry_post_json",
+            AsyncMock(return_value=make_response(body)),
+        ),
+        pytest.raises(AlchemyClientError),
+    ):
+        await get_token_price(USDC, "ethereum", date(2024, 1, 1))
+
+
+@pytest.mark.parametrize(
+    "network",
+    ["polygon", "optimism", "unichain", "linea", "scroll"],
+)
+async def test_prices_resolve_on_the_networks_added_for_the_compound_reserves_backfill(network):
+    post = AsyncMock(return_value=make_response({"data": [point(1, "1.0")]}))
+    with patch("chain_harvester_async.adapters.alchemy.retry_post_json", post):
+        assert await get_token_price(USDC, network, date(2024, 1, 1)) == Decimal("1.0")
+
+    assert post.await_args.kwargs["json"]["network"].endswith("-mainnet")
+
+
+async def test_unmapped_network_still_raises():
+    with pytest.raises(ValueError, match="ronin"):
+        await get_token_price(USDC, "ronin", date(2024, 1, 1))
+
+
+async def test_price_series_keys_daily_values_by_date():
+    body = {"data": [point(1, "0.9992"), point(2, "1.0012"), point(3, "1.0021")]}
+    with patch(
+        "chain_harvester_async.adapters.alchemy.retry_post_json",
+        AsyncMock(return_value=make_response(body)),
+    ):
+        prices = await get_token_price_series(USDC, "ethereum", date(2024, 1, 1), date(2024, 1, 3))
+
+    assert prices == {
+        date(2024, 1, 1): Decimal("0.9992"),
+        date(2024, 1, 2): Decimal("1.0012"),
+        date(2024, 1, 3): Decimal("1.0021"),
+    }
+
+
+async def test_price_series_chunks_windows_past_the_365_point_cap():
+    # The endpoint rejects a 1d interval spanning more than 365 points, so a multi-year
+    # backfill window has to be requested in successive chunks.
+    post = AsyncMock(return_value=make_response({"data": []}))
+    with patch("chain_harvester_async.adapters.alchemy.retry_post_json", post):
+        await get_token_price_series(USDC, "ethereum", date(2021, 1, 1), date(2023, 1, 1))
+
+    windows = [
+        (call.kwargs["json"]["startTime"], call.kwargs["json"]["endTime"])
+        for call in post.await_args_list
+    ]
+    assert windows == [
+        ("2021-01-01T00:00:00Z", "2021-12-31T00:00:00Z"),
+        ("2022-01-01T00:00:00Z", "2022-12-31T00:00:00Z"),
+        ("2023-01-01T00:00:00Z", "2023-01-01T00:00:00Z"),
+    ]
+
+
+async def test_price_series_is_empty_for_a_token_alchemy_does_not_price():
+    body = {"error": {"message": "Token not found: 0xeee"}}
+    with patch(
+        "chain_harvester_async.adapters.alchemy.retry_post_json",
+        AsyncMock(return_value=make_response(body)),
+    ):
+        prices = await get_token_price_series(USDC, "ethereum", date(2024, 1, 1), date(2024, 1, 3))
+
+    assert prices == {}


### PR DESCRIPTION
Supports blockanalitica/office#891 — the Compound reserves history backfill.

**Paired with:** blockanalitica/datahub#1434, which consumes `get_token_price_series` and **cannot merge until this is released.**

## Why

The reserves backfill needs historical USD prices for every base token on all 8 reserve networks, over a ~5-year window. Two things blocked that:

- **Five networks weren't in the price map.** `get_token_price` raised `ValueError` for polygon, optimism, unichain, linea and scroll — the reserve-only networks from office#809.
- **Per-date pricing doesn't scale.** One request per `(token, date)` is ~25k sequential calls for ethereum alone. DefiLlama is not the answer here: it rate-limits and dies mid-backfill (the #805 lesson), which is why the treasury backfill already prices off Alchemy (#875).

## What

- `PRICE_NETWORKS` — the network map lifted to a module constant and extended with the 5 reserve networks. Slugs verified live against the prices API (`polygon-mainnet`, `opt-mainnet`, `unichain-mainnet`, `linea-mainnet`, `scroll-mainnet`).
- `get_token_price_series(address, network, start_date, end_date)` → `{date: Decimal}`, chunked to the endpoint's 365-point cap for a `1d` interval. A 5-year window is 6 calls per token instead of ~1,900.
- `get_token_price` keeps its exact signature and behaviour; both now share `_fetch_prices`, so the "Token not found" → `None` and raise-on-other-errors handling stays in one place.
- Exposed on the facade as `prices.get_alchemy_token_price_series`.

## Verified

- New `tests/adapters/test_alchemy.py` (12 tests) covers single-date, unpriced-token, API-error, the 5 added networks, date-keying, the 365-day chunk boundaries and the empty-series case. Full suite 34 passed, ruff clean.
- Live smoke test: ethereum USDC 2021-03-29 → 2026-07-29 returned **1949 daily points** in 6 chunked calls (first 1.0013, last 0.9999); scroll USDC returned 30 points for a February 2024 window.

## Note

`monad` stays in the map but is unreachable — both entry points early-return for it before the lookup, exactly as before. Carried forward rather than cleaned up to keep this diff to the change at hand.

## After merge

release-please cuts the version; datahub is blocked until it lands on PyPI.

1. Merge this PR → release-please opens/updates a `chore(main): release …` PR.
2. **Merge that release PR** → tags + publishes to PyPI (`.github/workflows/release.yml`).
3. Confirm the published version — a `feat:` off the current `v2.26.4` should cut **2.27.0**:
   ```
   gh release list --repo blockanalitica/chain-harvester --limit 3
   ```
4. Set that exact version in datahub#1434 (its pin is a prediction, not a fact):
   ```
   cd ~/work/projects/datahub
   # edit pyproject.toml -> chain-harvester==<released version>
   uv lock && uv sync
   git commit -am "deps: bump chain-harvester for the reserves price series" && git push
   ```
